### PR TITLE
fixing some stuff in the WAIT FOR COMMIT article

### DIFF
--- a/Database-Features/wait-for-commit-on-select-statement.md
+++ b/Database-Features/wait-for-commit-on-select-statement.md
@@ -13,17 +13,18 @@ Three different connections (having AUTOCOMMIT off) are needed to reproduce this
 
 #### Example 1:
 
-If a long running transaction (Tr1) reads object A and writes object B (e.g. long running IMPORT statements) and a second transaction (Tr2) writes object A and commits in parallel, Tr2 is scheduled after   
-Tr1. AfterTr2 is commited all new transactions are scheduled after it. If such a transaction wants to read object B it has to wait for the commit of Tr1.
+If a long running transaction (nr. 1 in table below) reads object A and writes object B (e.g. long running IMPORT statements) and a second transaction (2 in table) writes object A and commits in parallel, Tr2 is scheduled after   
+Tr1 logicallym, but does not have to actually wait. After Tr2 is committed all new transactions are scheduled after it. If such a new transaction (3 below) wants to read object B it now has to wait for the commit of our inial transaction 1:
 
-| Transaction 1 | Transaction 2 | Transaction 3 | Comment |
-|---|---|---|---|
-|select * from tab1;   |   |   |   |
-|– transaction remains opened   |   |   |   |
-|   |insert into WFC.tab1 values 1;   |   |Transaction 1 < Transaction 2   |
-|   |commit;   |   |   |
-|   |   |commit;   |Starts a new transaction (Transaction 2 < Transaction 3)   |
-|   |   |select * from tab2;   |This statement ends up in WAIT FOR COMMIT, waiting for Transaction 1   |
+| Transaction 1              | Transaction 2 | Transaction 3 | Comment |
+|----------------------------|---|---|---|
+| select * from tab1;        |   |   |   |
+| insert into tab2 values 1; |   |   |   |
+| – transaction remains open |   |   |   |
+|                            |insert into tab1 values 1;   |   |Transaction 1 < Transaction 2   |
+|                            |commit;   |   |   |
+|                            |   |commit;   |Starts a new transaction (Transaction 2 < Transaction 3)   |
+|                            |   |select * from tab2;   |This statement ends up in WAIT FOR COMMIT, waiting for Transaction 1   |
 
 #### Example 2:
 
@@ -38,6 +39,7 @@ The same situation may occur if you query **system tables** while SqlLogServer i
 |   |   |commit;   |Starts a new transaction (LogServer transaction 2 < Transaction 3)   |
 |   |   |select * from EXA_DB_SIZE_LAST_DAY;   |This statement end up in WAIT FOR COMMIT   |
 
+Please note that the problem around system tables has been mitigated by introducing [automated metadata snapshot execution](https://exasol.my.site.com/s/article/Changelog-content-10122) in Exasol 7.0.
 
 ## Solution
 
@@ -46,7 +48,6 @@ However, things may get more complicated when the read/write operation is concen
 
 ## Additional References
 
-<https://community.exasol.com/t5/database-features/transaction-system/ta-p/1522>
-
-<https://community.exasol.com/t5/database-features/filter-on-system-tables-and-transaction-conflicts/ta-p/1232>
-
+1. <https://exasol.my.site.com/s/article/Transaction-System>
+2. <https://exasol.my.site.com/s/article/Filter-on-system-tables-and-transaction-conflicts>
+3. <https://exasol.my.site.com/s/article/Investigating-Transaction-Conflicts-using-Auditing>

--- a/Database-Features/wait-for-commit-on-select-statement.md
+++ b/Database-Features/wait-for-commit-on-select-statement.md
@@ -30,14 +30,15 @@ Tr1 logicallym, but does not have to actually wait. After Tr2 is committed all n
 
 The same situation may occur if you query **system tables** while SqlLogServer is performing one of its tasks (e.g. "DB size task" determining the database size). The following example describes this situation:
 
-| Transaction 1 | LogServer | Transaction 3 | Comment |
-|---|---|---|---|
-|select * from EXA_DB_SIZE_LAST_DAY;   |   |   |   |
-|insert into tab1 values 1;   |   |   |   |
-|– transaction remains opened   |   |   |   |
-|   |– DB size task (writes EXA_DB_SIZE_LAST_DAY)   |   |Transaction 1 < LogServer transaction, the task is executed every 30 minutes (0:00, 0:30, 1:00, 1:30, ...)   |
-|   |   |commit;   |Starts a new transaction (LogServer transaction 2 < Transaction 3)   |
-|   |   |select * from EXA_DB_SIZE_LAST_DAY;   |This statement end up in WAIT FOR COMMIT   |
+| Transaction 1 | LogServer                                    | Transaction 3 | Comment |
+|---|----------------------------------------------|---|---|
+|select * from EXA_DB_SIZE_LAST_DAY;   |                                              |   |   |
+|insert into tab1 values 1;   |                                              |   |   |
+|– transaction remains opened   |                                              |   |   |
+|   | – DB size task (writes EXA_DB_SIZE_LAST_DAY) |   |Transaction 1 < LogServer transaction, the task is executed every 30 minutes (0:00, 0:30, 1:00, 1:30, ...)   |
+|   | commit;                                      |   |   |
+|   |                                              |commit;   |Starts a new transaction (LogServer transaction 2 < Transaction 3)   |
+|   |                                              |select * from EXA_DB_SIZE_LAST_DAY;   |This statement end up in WAIT FOR COMMIT   |
 
 Please note that the problem around system tables has been mitigated by introducing [automated metadata snapshot execution](https://exasol.my.site.com/s/article/Changelog-content-10122) in Exasol 7.0.
 


### PR DESCRIPTION
I'm also pretty sure that in the second example, transaction 3 should read from `tab1`, not from `EXA_DB_SIZE_DAILY`; but that needs to be checked with the original author.
