### PR TITLE
Fix formatting and links for the 'Parallel connections with JDBC' article.

### DIFF
--- a/Database-Features/parallel-connections-with-jdbc.md
+++ b/Database-Features/parallel-connections-with-jdbc.md
@@ -1,4 +1,5 @@
 # Parallel connections with JDBC 
+
 ## Questions
 
 * **What data can you read using subconnections?**
@@ -21,19 +22,20 @@ You need a statement that produces a large result set. The result set can be the
 Like when reading data, using this interfaces only makes sense if you want to insert large amounts of data. You can simply insert rows into a table in EXASOL using a prepared insert statement. The data coming through the parallel connections will be put together by the server into the right table.
 
 **How to establish parallel connections?**  
-First you need a normal JDBC connection. On this you can use the `methodEnterParallel()` to start operating with subconnections. You will receive connection strings for all new parallel connections you can start now. Start the subconnections with auto commit off. After this you can start reading or sending data, nearly like in a normal connection.
+First you need a normal JDBC connection. On this you can use the method `EnterParallel()` to start operating with subconnections. You will receive connection strings for all new parallel connections you can start now. Start the subconnections with auto commit off. After this you can start reading or sending data, nearly like in a normal connection.
 
-**Attention**: You can specify the maximum number of subconnections `inEnterParallel()`. This number may be reduced by the server because only one subconnection is allowed per database node.  
-You have to establish the subconnections by using all connection strings received `fromGetWorkerHosts()`. Subconnections can only be used after all connections have been established.
+**Attention**: You can specify the maximum number of subconnections in `EnterParallel()`. This number may be reduced by the server because only one subconnection is allowed per database node.  
+You have to establish the subconnections by using all connection strings received from `GetWorkerHosts()`. Subconnections can only be used after all connections have been established.
 
 **What about transactions in parallel mode?**  
 Start the subconnections with auto commit off.  
 Commits should be made only on the main connection after the subconections have inserted all data and they have closed the prepared statements.
 
-**An Java example is attached.**  
-In the example a main connection reads the connection strings for the subconnections from the server. For each subconnection a thread is started that inserts a few rows. Commit is executed on the main connection. Then other threads read the data from the table.
+**A Java example is linked.**
+In the linked example a main connection reads the connection strings for the subconnections from the server. For each subconnection a thread is started that inserts a few rows. Commit is executed on the main connection. Then other threads read the data from the table.
 
-## Downloads
-[ParallelConnectionsExample.zip](https://github.com/exasol/Public-Knowledgebase/files/9937141/ParallelConnectionsExample.zip)
+## Additional References
+
+The script itself: [ParallelConnectionsExample.java](https://raw.githubusercontent.com/exasol/exa-toolbox/master/utilities/ParallelConnectionsExample.java)
 
 *We appreciate your input! Share your knowledge by contributing to the Knowledge Base directly in [GitHub](https://github.com/exasol/public-knowledgebase).* 


### PR DESCRIPTION
- Fix formatting for code pieces inside the text.
- Switch from attaching example program text to linking to exa-toolbox repo.