### PR TITLE
Improve the ldapsearch call

### DIFF
--- a/Database-Features/manual-ldap-connection-test.md
+++ b/Database-Features/manual-ldap-connection-test.md
@@ -7,12 +7,12 @@ There might be a configuration problem with your LDAP server, the distinguished 
 
 ## Solution
 
-Try to connect/bind to your LDAP server with the ldapsearch command line tool. If you cannot connect with ldapsearch, the database won't be able to connect the LDAP user.  
+Try to connect/bind to your LDAP server with the `ldapsearch` command line tool. If you cannot connect with `ldapsearch`, the database won't be able to connect the LDAP user.  
 Here is a simple example:
 
 
-```
-ldapsearch -v -x -D "uid=Ben,ou=People,dc=myserv,dc=com" -w my_password -H ldap://my_ldap_server.com
+```shell
+LDAPTLS_REQCERT=never ldapsearch -v -x -D "uid=Ben,ou=People,dc=myserv,dc=com" -w my_password -H ldap://my_ldap_server.com
 ```
 
 *We appreciate your input! Share your knowledge by contributing to the Knowledge Base directly in [GitHub](https://github.com/exasol/public-knowledgebase).* 


### PR DESCRIPTION
I believe it makes sense to skip TLS certificate verification during the diagnostic, as DB is not currently checking those too.