### PR TITLE
Emergency update for compromised 3rd party github action

### DIFF
--- a/.github/workflows/markdown_lint.yml
+++ b/.github/workflows/markdown_lint.yml
@@ -16,7 +16,7 @@ jobs:
         files: '**/*.md'
         separator: ","
 
-    - uses: DavidAnson/markdownlint-cli2-action@v105f32210e84442804257b2a6f20b273450ec8265
+    - uses: DavidAnson/markdownlint-cli2-action@05f32210e84442804257b2a6f20b273450ec8265
       # version 19.1.0 as of 2025-03-19
       if: steps.changed-files.outputs.any_changed == 'true'
       with:

--- a/.github/workflows/markdown_lint.yml
+++ b/.github/workflows/markdown_lint.yml
@@ -9,13 +9,15 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: tj-actions/changed-files@v45
+    - uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32
+      # version 46.0.1 as of 2025-03-19
       id: changed-files
       with:
         files: '**/*.md'
         separator: ","
 
-    - uses: DavidAnson/markdownlint-cli2-action@v19
+    - uses: DavidAnson/markdownlint-cli2-action@v105f32210e84442804257b2a6f20b273450ec8265
+      # version 19.1.0 as of 2025-03-19
       if: steps.changed-files.outputs.any_changed == 'true'
       with:
         globs: ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
# Problem

As reported at

- https://www.heise.de/news/Attacke-ueber-GitHub-Action-Tool-spaehte-Secrets-aus-und-legte-sie-in-Logdatei-ab-10320979.html
- https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised
- https://www.wiz.io/blog/new-github-action-supply-chain-attack-reviewdog-action-setup

The "changed files" action was compromised to scan project files for any secrets and dump them in the project log for any attacker to collect them.

# Fix

- update actions to corrected versions
- pin versions to specific commit SHA to prevent new attacks overwriting / adding on the used version tags
