### PR TITLE
Clarify Prepared Parameters usage in scripts

### DIFF
--- a/Connect-with-Exasol/what-to-do-when-bind-variables-for-prepared-statements-does-not.md
+++ b/Connect-with-Exasol/what-to-do-when-bind-variables-for-prepared-statements-does-not.md
@@ -1,4 +1,5 @@
-# What to do when Bind Variables for Prepared Statements do not work 
+# What to do when Bind Variables for Prepared Statements do not work
+
 ## Problem
 
 Bind Variables in prepared statements for executing a script do not work.
@@ -7,13 +8,13 @@ Bind Variables in prepared statements for executing a script do not work.
 
 When the user executes this statement `con.prepareStatement( "EXECUTE SCRIPT LUASCRIPT ?" )` in a java program, the user gets an error like this:
 
-
-```
+```text
 java.sql.SQLSyntaxErrorException: syntax error, unexpected '?', 
 expecting END_OF_INPUT_ or ';' [line 1, column 26] (Session: 1681284472046092288)  
 at com.exasol.jdbc.ExceptionFactory.createSQLException(ExceptionFactory.java:39)  
 ...
 ```
+
 ## Explanation
 
 We do not support Prepared Parameters in EXECUTE SCRIPT statements. 
@@ -26,19 +27,16 @@ Example:
 
 Assume, that we have a script that creates a table based upon the parameter. 
 
-
 ```lua
 --/  
 CREATE or REPLACE lua SCRIPT test.my_script_old (table_name) AS  
 query([[create table ::t (a int )]], {t=table_name})  
 /  
-  
-
 ```
+
 We have to rewrite our example script:
 
 It now reads the values from a table test.temp
-
 
 ```lua
 CREATE or REPLACE lua SCRIPT test.my_script_new () AS  
@@ -49,7 +47,6 @@ CREATE or REPLACE lua SCRIPT test.my_script_new () AS
 ```
 
 So, we can use it now in our java class as follow:
-
 
 ```java
 // create temporary table  
@@ -62,7 +59,7 @@ stmt.setString(1, "test.testtable");
 stmt.execute();  
   
 // execute the script  
-stmt = con.prepareStatement( "execute script test.my_script()" );  
+stmt = con.prepareStatement( "execute script test.my_script_new()" );  
 stmt.execute();  
   
 // drop the temporary table  
@@ -72,6 +69,7 @@ stmt.execute();
 // commit  
 con.commit();
 ```
+
 ## Additional References
 
 * [Database Interaction](https://docs.exasol.com/database_concepts/scripting/db_interaction.htm)
@@ -81,4 +79,4 @@ con.commit();
 
 * [Bind_variables_not_working_example.java](https://github.com/exasol/public-knowledgebase/blob/main/Connect-with-Exasol/attachments/Bind_variables_not_working_example.java)
 
-*We appreciate your input! Share your knowledge by contributing to the Knowledge Base directly in [GitHub](https://github.com/exasol/public-knowledgebase).* 
+*We appreciate your input! Share your knowledge by contributing to the Knowledge Base directly in [GitHub](https://github.com/exasol/public-knowledgebase).*

--- a/Connect-with-Exasol/what-to-do-when-bind-variables-for-prepared-statements-does-not.md
+++ b/Connect-with-Exasol/what-to-do-when-bind-variables-for-prepared-statements-does-not.md
@@ -17,7 +17,7 @@ at com.exasol.jdbc.ExceptionFactory.createSQLException(ExceptionFactory.java:39)
 
 ## Explanation
 
-We do not support Prepared Parameters in EXECUTE SCRIPT statements. 
+We do not support Prepared Parameters in EXECUTE SCRIPT statements.
 
 ## Recommendation
 
@@ -25,7 +25,7 @@ As a workaround, to prevent SQL injection, you can insert the parameter value in
 
 Example:
 
-Assume, that we have a script that creates a table based upon the parameter. 
+Assume, that we have a script that creates a table based upon the parameter.
 
 ```lua
 --/  


### PR DESCRIPTION
Updated the document to clarify that Prepared Parameters are not supported in EXECUTE SCRIPT statements and provided an example of how to rewrite the script accordingly.